### PR TITLE
Updated redux to version 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-router": "0.13.3",
     "react-tap-event-plugin": "0.1.8",
     "react-transmit": "2.6.4",
-    "redux": "1.0.1",
+    "redux": "3.0.2",
     "webpack": "1.12.2"
   },
   "devDependencies": {


### PR DESCRIPTION
:rocket:

redux just published version 3.0.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

[GitHub Release](https://github.com/rackt/redux/releases/tag/v3.0.2)

One of the problems [v3.0.1](https://github.com/rackt/redux/releases/tag/v3.0.1) was intended to solve [was not completely fixed in 3.0.1](https://github.com/rackt/redux/issues/717#issuecomment-143403628).
This release amends that.
- An error thrown inside reducer during the `combineReducer()` sanity check will be delayed until the first dispatch. This lets Redux DevTools correctly handle it and recover from the error. (#717, #761, #807, gaearon/redux-devtools#106, gaearon/redux-devtools#120)

To enjoy this, you’ll need at least `redux-devtools@2.1.4`.

![](http://i.imgur.com/skmH0uC.gif)

---

The new version differs by 312 commits (ahead by 312, behind by 0).
- [5910b9a](https://github.com/rackt/redux/commit/5910b9a255c1be58f16247e621ee96dc2d5f1a7e): 3.0.2
- [a1485f0](https://github.com/rackt/redux/commit/a1485f0e30ea0ea5e023a6d0f5947bd56edff7dd): Refactor warnings and errors in combineReducers()
- [6fd9b05](https://github.com/rackt/redux/commit/6fd9b051585c10b815c5e7f3d691d0ccf93eb3c1): Catch and rethrow error from reducer init in combineReducers
- [96e8b3e](https://github.com/rackt/redux/commit/96e8b3e1c668851c11702bb337ef605efbdcfcaf): 3.0.1
- [78c29b7](https://github.com/rackt/redux/commit/78c29b7efc259e3a0eeb22d503214271acec09fd): Merge pull request #796 from gcanti/add-prefix-to-randomly-generated-type
- [3f02418](https://github.com/rackt/redux/commit/3f02418706dc6cfdb3da81a8861038e5c2f17a26): Merge pull request #801 from julen/docs/migrating
- [f537111](https://github.com/rackt/redux/commit/f537111c53bd80f11b4a4cde468ebb67cddaaaaf): Migrating docs: point to `createStore()` source file
- [9f02037](https://github.com/rackt/redux/commit/9f020376d196303045a01ebc779fbab84ddc78a8): Merge pull request #804 from chentsulin/patch-11
- [85d905f](https://github.com/rackt/redux/commit/85d905f6e299017b94ae1dad72df0c5efaced7a7): Merge pull request #799 from gsklee/patch-2
- [3e9a8fe](https://github.com/rackt/redux/commit/3e9a8fe2c306548e85f02e4955bb15fff5da4708): Update bindActionCreators.md
- [1150c53](https://github.com/rackt/redux/commit/1150c53ada0b9fc3a0314bf0cd0edec24c301c6f): Update ServerRendering.md
- [c39ee57](https://github.com/rackt/redux/commit/c39ee57581e59d31f4d5d0e2f6e7bc7c22ba1403): Add prefix to randomly generated action type in combineReducers #792
- [a44b5e6](https://github.com/rackt/redux/commit/a44b5e688456c82a4ec04ba385a96794139a40f1): Merge pull request #794 from pedrottimark/universal-example-inconsistencies
- [1170c2c](https://github.com/rackt/redux/commit/1170c2c0824ae48652311654a6c6cc844169be59): add todos-with-undo to Examples.md
- [72b0fe3](https://github.com/rackt/redux/commit/72b0fe32713413cd1c387751096b20250e0f7e7c): Update README.md

There are 250 commits in total. See the [full diff](https://github.com/rackt/redux/compare/7cf753f428ad70c04acd2648e7f329ee578f4fdd...5910b9a255c1be58f16247e621ee96dc2d5f1a7e).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
