### PR TITLE
windows/heroku fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "watch-server": "webpack --watch --verbose --colors --display-error-details --config configs/webpack.server-watch.js",
     "watch-server-start": "node node_modules/just-wait --pattern \"dist/*.js\" && npm run start",
     "watch-client": "webpack-dev-server --config configs/webpack.client-watch.js",
-    "production": "NODE_ENV=production npm run build && NODE_ENV=production npm run start",
+    "production": "cross-env NODE_ENV=production npm run build && cross-env NODE_ENV=production npm run start",
     "dev": "concurrently --kill-others \"npm run watch-server-start\" \"npm run watch-server\" \"npm run watch-client\"",
     "postinstall": "webpack -p --config configs/webpack.client.js"
   },
@@ -42,6 +42,7 @@
     "babel-preset-react": "6.5.0",
     "babel-preset-react-hmre": "1.1.1",
     "babel-preset-stage-0": "6.5.0",
+    "cross-env": "^1.0.7",
     "file-loader": "^0.8.5",
     "forever": "0.15.1",
     "h2o2": "^5.1.0",

--- a/src/server.js
+++ b/src/server.js
@@ -18,12 +18,17 @@ let routes = routesContainer;
 const store = configureStore();
 const initialState = store.getState();
 /**
- * Start Hapi server on port 8000.
+ * Start Hapi server
  */
-const hostname = process.env.HOSTNAME || "localhost";
+var envset = {
+  production: process.env.NODE_ENV === 'production'
+};
+
+const hostname = envset.production ? (process.env.HOSTNAME || process['env'].HOSTNAME) : "localhost";
+var port = envset.production ? (process.env.PORT || process['env'].PORT) : 8000
 const server = new Server();
 
-server.connection({host: hostname, port: process.env.PORT || 8000});
+server.connection({host: hostname, port: port});
 
 server.register(
 	[


### PR DESCRIPTION
*using cross-env for setting env variables on windows
*had issues with heroku - process.env was being overwritten with custom environment values, so am falling back to ["env"] which seems to work.
