### PR TITLE
Fix Heroku deploy issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-preset-react": "6.5.0",
     "babel-preset-react-hmre": "1.1.1",
     "babel-preset-stage-0": "6.5.0",
+    "concurrently": "^2.0.0",
     "cross-env": "^1.0.7",
     "file-loader": "^0.8.5",
     "forever": "0.15.1",
@@ -59,17 +60,16 @@
     "react-tap-event-plugin": "0.2.2",
     "redux": "^3.3.1",
     "redux-thunk": "^2.0.1",
-    "webpack": "^1.12.14"
+    "webpack": "^1.12.14",
+    "webpack-node-externals": "^1.0.0"
   },
   "devDependencies": {
-    "concurrently": "^2.0.0",
     "eslint": "^2.3.0",
     "eslint-config-airbnb": "^6.1.0",
     "eslint-plugin-react": "^4.2.1",
     "json-loader": "^0.5.4",
     "just-wait": "1.0.5",
-    "webpack-dev-server": "^1.14.1",
-    "webpack-node-externals": "^1.0.0"
+    "webpack-dev-server": "^1.14.1"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/src/actions/StargazersActions.js
+++ b/src/actions/StargazersActions.js
@@ -6,8 +6,8 @@ import {
 
 let githubApi = "https://api.github.com";
 if (__CLIENT__) {
-	const { hostname, port } = window.location;
-	githubApi = `http://${hostname}:${port}/api/github`;
+	const { protocol, hostname, port } = window.location;
+	githubApi = `${protocol}//${hostname}:${port}/api/github`;
 }
 
 function receiveUsers(fetchedStargazers) {


### PR DESCRIPTION
by moving npm packages required for build and run to dependencies section
and by dynamically setting the protocol of the API.

[Fixes #80]
