### PR TITLE
Upgrade to React Hot Loader

### DIFF
--- a/configs/webpack.client-watch.js
+++ b/configs/webpack.client-watch.js
@@ -37,7 +37,7 @@ config.plugins = [
 ];
 
 config.module.postLoaders = [
-	{test: /\.js$/, loaders: ["babel?cacheDirectory&presets[]=es2015&presets[]=stage-0&presets[]=react&presets[]=react-hmre"], exclude: /node_modules/}
+	{test: /\.js$/, loaders: ['react-hot', "babel?cacheDirectory&presets[]=es2015&presets[]=stage-0&presets[]=react"], exclude: /node_modules/}
 ];
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "eslint-plugin-react": "^5.2.2",
     "json-loader": "^0.5.4",
     "just-wait": "1.0.5",
-    "webpack-dev-server": "^1.14.1"
+    "webpack-dev-server": "^1.14.1",
+    "react-hot-loader": "^1.3.0"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/package.json
+++ b/package.json
@@ -64,8 +64,10 @@
     "webpack-node-externals": "^1.3.0"
   },
   "devDependencies": {
-    "eslint": "^3.1.1",
+    "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.1",
+    "eslint-plugin-import": "^1.12.0",
+    "eslint-plugin-jsx-a11y": "^1.2.0",
     "eslint-plugin-react": "^5.2.2",
     "json-loader": "^0.5.4",
     "just-wait": "1.0.5",


### PR DESCRIPTION
Attempt to address #99  

I didn't remove the old hot loading module quite yet. Hot Loading did not work in general for me on OS X / Node V5 and V6 until I made this update. If this works for you feel free to merge. I can remove the old hot module reloading code with another PR. I tried originally but ran into some issues that I have since had trouble reproducing.

I also updated package.json to fix eslint config. The peer deps for Airbnb config were not being met. 
